### PR TITLE
Update v17 for SimpleMachines Appliance

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,14 @@
+turnkey-simplemachines-17.0 (1) turnkey; urgency=low
+
+  * Update SimpleMachines and its dependencies to v17.
+
+  * Update libinit hooks cache and dialog_wrapper imports for refactoring in v17.
+
+  * Note: Please refer to turnkey-core's 17.0 changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Mattie Darden <mattie@turnkeylinux.org>  Wed, 14 Sep 2022 15:52:31 +0000
+
 turnkey-simplemachines-16.1 (1) turnkey; urgency=low
 
   * Updated to latest upstream version of SimpleMachines - 2.0.18.

--- a/changelog
+++ b/changelog
@@ -2,6 +2,8 @@ turnkey-simplemachines-17.0 (1) turnkey; urgency=low
 
   * Update SimpleMachines and its dependencies to v17.
 
+  * Update appliance and curl install to new smp v2.1.2.
+
   * Update libinit hooks cache and dialog_wrapper imports for refactoring in v17.
 
   * Note: Please refer to turnkey-core's 17.0 changelog for changes common to all

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,7 +5,7 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="2-0-18"
+VERSION="2-1-2"
 URL="https://download.simplemachines.org/index.php/smf_${VERSION}_install.tar.gz"
 
 dl $URL /usr/local/src

--- a/conf.d/main
+++ b/conf.d/main
@@ -54,7 +54,7 @@ $CURL "${URL}?step=0" --data "contbutt=Continue"
 $CURL "${URL}?step=2" --data "db_type=mysql&db_server=localhost&db_user=$DB_USER&db_passwd=$DB_PASS&db_name=$DB_NAME&db_prefix=&contbutt=Continue"
 $CURL "${URL}?step=3" --data "mbname=TurnKey+SimpleMachines&boardurl=http%3A%2F%2F$DOMAIN&dbsession=on&utf8=on&contbutt=Continue"
 $CURL "${URL}?step=4" --data "pop_done=1&contbutt=Continue"
-$CURL "${URL}?step=5" --data "username=$ADMIN_NAME&password1=$ADMIN_PASS&password2=$ADMIN_PASS&email=$EMAIL&password3=$DB_PASS&contbutt=Continue"
+$CURL "${URL}?step=5" --data "username=$ADMIN_NAME&password1=$ADMIN_PASS&password2=$ADMIN_PASS&email=$EMAIL&server_email=$EMAIL&password3=$DB_PASS&contbutt=Continue"
 
 rm $WEBROOT/install*
 rm -f /tmp/cookie

--- a/overlay/usr/lib/inithooks/bin/simplemachines.py
+++ b/overlay/usr/lib/inithooks/bin/simplemachines.py
@@ -10,13 +10,14 @@ Option:
 
 import sys
 import getopt
-from libinithooks import inithooks_cache
+import subprocess
 
 import hashlib
 
+from libinithooks import inithooks_cache
 from libinithooks.dialog_wrapper import Dialog
 from mysqlconf import MySQL
-import subprocess
+
 
 def usage(s=None):
     if s:

--- a/overlay/usr/lib/inithooks/bin/simplemachines.py
+++ b/overlay/usr/lib/inithooks/bin/simplemachines.py
@@ -10,11 +10,11 @@ Option:
 
 import sys
 import getopt
-import inithooks_cache
+from libinithooks import inithooks_cache
 
 import hashlib
 
-from dialog_wrapper import Dialog
+from libinithooks.dialog_wrapper import Dialog
 from mysqlconf import MySQL
 import subprocess
 

--- a/plan/main
+++ b/plan/main
@@ -4,6 +4,6 @@
 php-gd
 php-cli
 php-curl
+php-mbstring
 
 unzip
-


### PR DESCRIPTION
Update so far includes updating refactored libinithooks for cache and dialog_wrapper imports. Investigating smp login bug, build code does give simplemachines.iso image, but need to ensure smp login is set at install.