### PR TITLE
18.0 extra

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,8 @@ turnkey-simplemachines-18.0 (1) turnkey; urgency=low
   * Updated to latest upstream version of SimpleMachines - 2.1.4.
     [Anton Pyrogovskyi <anton@turnkeylinux.org>]
 
+  * DEV: Auto download latest version.
+
   * Confconsole: bugfix broken DNS-01 Let's Encrypt challenge- closes #1876 &
     #1895.
     [Jeremy Davis <jeremy@turnkeylinux.org>]
@@ -94,7 +96,7 @@ turnkey-simplemachines-18.0 (1) turnkey; urgency=low
 
   * Use MariaDB (MySQL replacement) v10.11.3 (from debian repos).
 
- -- Jeremy Davis <jeremy@turnkeylinux.org>  Wed, 13 Mar 2024 07:45:28 +0000
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 14 Mar 2024 00:04:14 +0000
 
 turnkey-simplemachines-17.1 (1) turnkey; urgency=low
 

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -1,12 +1,18 @@
 #!/bin/bash -ex
 
 dl() {
-    [ "$FAB_HTTP_PROXY" ] && PROXY="--proxy $FAB_HTTP_PROXY"
-    cd $2; curl -L -f -O $PROXY $1; cd -
+    [[ "$FAB_HTTP_PROXY" ]] && PROXY="--proxy $FAB_HTTP_PROXY"
+    cd $2
+    curl -L -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0' \
+         -f -O $PROXY $1
+    cd -
 }
 
-VERSION="2-1-4"
+VERSION=$(gh_releases SimpleMachines/SMF | sort -V \
+            | grep -v alpha | grep -v beta | grep -v rc | tail -1)
+VERSION=${VERSION#v}
+VERSION=${VERSION//./-}
+
 URL="https://download.simplemachines.org/index.php/smf_${VERSION}_install.tar.gz"
 
 dl $URL /usr/local/src
-


### PR DESCRIPTION
Update `conf.d/downloads` to include user agent in curl command - otherwise get 403.

Also get latest version dynamically.